### PR TITLE
Backend fix images

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -65,8 +65,9 @@ Editor-view: Json visual Editor
 | `/api/books/`          | `GET`     | Liste aller Bücher  |
 | `/api/books/:bookId`   | `GET`     | Finde ein bestimmtes Buch  |
 | `/api/books/:bookId`   | `PUT`     | Verändere Buch  |
+| `/api/books/image/:bookId` | `PUT` | Verändere nur das Bild von Buch |
 | `/api/books/:bookId`   | `DELETE`  | Lösche Buch  |
-| `/api/books/user/::userId`| 'GET' | Erhalte alle Bücher eines bestimmten Users|
+| `/api/books/user/:userId`| 'GET' | Erhalte alle Bücher eines bestimmten Users|
 
 ### Bücher Felder in der Datenbank
 | Feld        | Typ           | Beschreibung  |
@@ -88,6 +89,7 @@ Editor-view: Json visual Editor
 | `/api/messages`          |`POST`     | Erstelle Nachricht/Konversation     |
 | `/api/messages/:convId`   | `GET`     | Erhalte Konversation  |
 | `/api/messages/:convId`   | `POST`     | Schicke Nachricht/Update Konversation  |
+| `/api/messages/:convId`   | `DELETE`     | Lösche Konversation  |
 | `/api/messages/user/:userId`   | `GET`     | Erhalte alle Nachrichten vom User  |
 
 ### Nachrichten Felder in der Datenbank

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -64,7 +64,8 @@ const requireSignin = expressJwt({
 // Darf der Benutzer die Aktion ausfuehren?
 // Sein eigenes Profil bearbeiten ist in Ordnung
 const hasAuthorization = (req, res, next) => {
-    const authorized = req.profile && req.auth && req.profile._id == req.auth._id
+    const authorized = req.profile && req.auth && (req.profile._id == req.auth._id)
+
     if (!(authorized)) {
         return res.status('403').json({
             error: "User is not authorized"
@@ -73,19 +74,31 @@ const hasAuthorization = (req, res, next) => {
     next()
 }
 
+const hasAuthorizationForNewMessage = (req, res, next) => {
+    const authorized = (req.body.sender == req.auth._id)
+    console.log(req.body.sender, req.auth._id)
+
+    if (!(authorized)) {
+        return res.status('403').json({
+            error: "User is not the sender of the new message"
+        })
+    }
+    next()
+}
+
 const hasAuthorizationForConversation = (req, res, next) => {
     let isrecipient = false
     req.conv.recipients.forEach(recipient => {
-        if (recipient == req.auth._id) {
+        if (recipient._id == req.auth._id) {
             isrecipient = true
         }
     });
 
-    let authorized = req.post && req.auth && isrecipient
+    let authorized = req.auth && isrecipient
 
     if (!(authorized)) {
         return res.status('403').json({
-            error: "User is not authorized"
+            error: "User is not part of conversation"
         })
     }
     next()
@@ -97,10 +110,10 @@ const hasAuthorizationForBook = (req, res, next) => {
     const authorized = req.profile.owner == req.auth._id
     if (!(authorized)) {
         return res.status('403').json({
-            error: "User " + req.auth._id + " is not authorized"
+            error: "User is not authorized for book"
         })
     }
     next()
 }
 
-export default { signin, signout, requireSignin, hasAuthorization, hasAuthorizationForBook, hasAuthorizationForConversation }
+export default { signin, signout, requireSignin, hasAuthorization, hasAuthorizationForBook, hasAuthorizationForConversation, hasAuthorizationForNewMessage }

--- a/server/controllers/book.controller.js
+++ b/server/controllers/book.controller.js
@@ -8,6 +8,7 @@ const create = async (req, res) => {
         const book = new Book(req.body);
         try {
             book.image = res.locals.BookUrl
+            book.imagekitIoId = res.locals.BookImageId
         } catch (err) {
             return res.status(400).json({
                 message: 'You need to upload an image',
@@ -98,6 +99,26 @@ const update = async (req, res) => {
     }
 };
 
+const updateWithImage = async (req, res) => {
+    try {
+        // Get Book
+        let book = req.profile;
+
+        // Update image, image_id and timestamp
+        book.image = res.locals.BookUrl
+        book.imagekitIoId = res.locals.BookImageId
+        book.updated = Date.now();
+
+        // Save modified book to db
+        await book.save();
+        res.json(book);
+    } catch (err) {
+        return res.status(400).json({
+            error: errorHandler.getErrorMessage(err),
+        });
+    }
+};
+
 //lösche Buch
 const remove = async (req, res) => {
     try {
@@ -125,6 +146,7 @@ export default {
     bookByID,
     read,
     update,
+    updateWithImage,
     remove,
     bookByUser
 };

--- a/server/controllers/book.controller.js
+++ b/server/controllers/book.controller.js
@@ -63,7 +63,7 @@ const bookByID = async (req, res, next, id) => {
         let book = await Book.findById(id);
         if (!book) {
             return res.status('400').json({
-                error: 'Buch not found',
+                error: 'Book not found',
             });
         }
         req.profile = book;
@@ -83,11 +83,10 @@ const read = (req, res) => {
 //verändere Buch mit PUT
 const update = async (req, res) => {
     try {
+        // Get Book
         let book = req.profile;
-        //Verändern des Bildes und löschen des alten Bildes
-        // TBD
-
         //Verändern der restlichen Buchdaten
+        // Update via json
         book = extend(book, req.body);
         book.updated = Date.now();
         await book.save();
@@ -105,10 +104,14 @@ const remove = async (req, res) => {
         let book = req.profile;
         //löscht Bild des Buches aus der Datenbank
         // Loescht Bild vom Server? tbd
-
+        console.log(book);
         //löscht die restlichen Buchdaten
         let deletedBook = await book.remove();
-        res.json(deletedBook);
+
+        return res.status(200).json({
+            message: 'Book successfully deleted!',
+            book: deletedBook,
+        });
     } catch (err) {
         return res.status(400).json({
             error: errorHandler.getErrorMessage(err),

--- a/server/controllers/image.controller.js
+++ b/server/controllers/image.controller.js
@@ -53,6 +53,9 @@ const UploadBookImageToImagekit = function (req, res, next) {
     }).then(response => {
         // Add the image url to the response
         res.locals.BookUrl = response.url;
+        console.log(res.locals.BookUrl)
+        // Add the image id to the response for deleting
+        res.locals.BookImageId = response.fileId;
         next();
     }).catch(error => {
         res.send(error)
@@ -61,9 +64,9 @@ const UploadBookImageToImagekit = function (req, res, next) {
 
 // For later for removing pictures from the db
 const MoveBookToDeleteFolder = (req, res, next) => {
-    const fileName = req.book.image.split("/").pop()[0]
+    const fileName = req.profile.image.split("/").pop()
     const sourceFilePath = "/b/" + fileName;
-    const destinationPath = "/d/" + fileName;
+    const destinationPath = "/d/";
 
     imagekitUpload.moveFile(sourceFilePath, destinationPath).then(response => {
         console.log(response);
@@ -74,8 +77,36 @@ const MoveBookToDeleteFolder = (req, res, next) => {
     });
 }
 
+// We need the id to delete the file
+const DeleteBookImage = (req, res, next) => {
+    // Find by file name and file path
+    const fileName = req.profile.image.split("/").pop()
+    let ImageId = 0;
+    imagekitUpload.listFiles({
+        searchQuery: 'name=' + fileName + ' AND filePath="b"'
+    }, function (error, result) {
+        if (error) console.log(error);
+        else {
+            console.log(result);
+            ImageId = result.fileId
+        }
+    });
+
+    if (ImageId != 0) {
+        imagekitUpload.deleteFile(ImageId, function (error, result) {
+            if (error) console.log(error);
+            else console.log(result);
+        });
+    }
+    else {
+        res.send("Image not found")
+    }
+
+}
+
 export default {
     UploadImageToMemory,
     UploadBookImageToImagekit,
-    ShowUploadInfo
+    ShowUploadInfo,
+    MoveBookToDeleteFolder
 };

--- a/server/controllers/image.controller.js
+++ b/server/controllers/image.controller.js
@@ -53,7 +53,6 @@ const UploadBookImageToImagekit = function (req, res, next) {
     }).then(response => {
         // Add the image url to the response
         res.locals.BookUrl = response.url;
-        console.log(res.locals.BookUrl)
         // Add the image id to the response for deleting
         res.locals.BookImageId = response.fileId;
         next();

--- a/server/models/book.model.js
+++ b/server/models/book.model.js
@@ -17,6 +17,10 @@ const BookSchema = new mongoose.Schema({
         type: String,
         required: 'Kein Bild ausgewählt',
     },
+    imagekitIoId: {
+        type: String,
+        required: 'Kein Bild ausgewählt',
+    },
     category: {
         type: String,
         trim: true,

--- a/server/models/book.model.js
+++ b/server/models/book.model.js
@@ -36,12 +36,10 @@ const BookSchema = new mongoose.Schema({
         type: String,
         required: "Bitte beschreibe dein Buch"
     },
-    //User ID, kann momentan nur manuell eingetragen werden?
-    // Erstmal einen String zum testen
+    //User ID
     owner: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User',
-        //type: String,
         required: "Bitte einen User eintragen"
     },
     status: {	//privat, bereit zum Verleihen, verliehen

--- a/server/routes/book.routes.js
+++ b/server/routes/book.routes.js
@@ -17,10 +17,30 @@ router.route('/api/books')
 router.route('/api/books/user/:userId')
     .get(bookCtrl.bookByUser)
 
+// check for muliform-data
+// Cond Route for book image change
+function skipThisRouteMiddleware(req, res, next) {
+    console.log(req.body)
+    if (req.body.bookImage !== undefined) {
+        // Upload New Image
+        return next();
+    }
+
+    // Jump to next put route
+    return next('route');
+}
+
+// With new image
+router.route('/api/books/:bookId')
+    .put(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, skipThisRouteMiddleware, imgCtrl.UploadImageToMemory, imgCtrl.UploadBookImageToImagekit, bookCtrl.update) // Update with PUT
+
+// Without new image
+router.route('/api/books/:bookId')
+    .put(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, bookCtrl.update) // Update with PUT
+
 router.route('/api/books/:bookId')
     .get(bookCtrl.read) //keine Registrierung nötig
-    .put(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, bookCtrl.update) // Update with PUT
-    .delete(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, bookCtrl.remove) // Remove with DELETE
+    .delete(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, imgCtrl.MoveBookToDeleteFolder, bookCtrl.remove) // Remove with DELETE
 
 router.param('bookId', bookCtrl.bookByID)
 

--- a/server/routes/book.routes.js
+++ b/server/routes/book.routes.js
@@ -9,37 +9,17 @@ router.route('/api/books')
     .get(bookCtrl.list) //Seite mit allen hochgeladenen Büchern
     .post(authCtrl.requireSignin, imgCtrl.UploadImageToMemory, imgCtrl.UploadBookImageToImagekit, bookCtrl.create) // login notwendig
 
-// For testing picture upload
-//router.route('/api/books/upload')
-//    .post(imgCtrl.UploadImageToMemory, imgCtrl.ShowUploadInfo, imgCtrl.UploadBookImageToImagekit)
-
 // New Route to getBooks by User
 router.route('/api/books/user/:userId')
     .get(bookCtrl.bookByUser)
 
-// check for muliform-data
-// Cond Route for book image change
-function skipThisRouteMiddleware(req, res, next) {
-    console.log(req.body)
-    if (req.body.bookImage !== undefined) {
-        // Upload New Image
-        return next();
-    }
-
-    // Jump to next put route
-    return next('route');
-}
-
 // With new image
-router.route('/api/books/:bookId')
-    .put(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, skipThisRouteMiddleware, imgCtrl.UploadImageToMemory, imgCtrl.UploadBookImageToImagekit, bookCtrl.update) // Update with PUT
-
-// Without new image
-router.route('/api/books/:bookId')
-    .put(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, bookCtrl.update) // Update with PUT
+router.route('/api/books/image/:bookId')
+    .put(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, imgCtrl.UploadImageToMemory, imgCtrl.UploadBookImageToImagekit, bookCtrl.updateWithImage) // Update with PUT
 
 router.route('/api/books/:bookId')
     .get(bookCtrl.read) //keine Registrierung nötig
+    .put(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, bookCtrl.update) // Update with PUT
     .delete(authCtrl.requireSignin, authCtrl.hasAuthorizationForBook, imgCtrl.MoveBookToDeleteFolder, bookCtrl.remove) // Remove with DELETE
 
 router.param('bookId', bookCtrl.bookByID)

--- a/server/routes/conversation.routes.js
+++ b/server/routes/conversation.routes.js
@@ -1,27 +1,30 @@
 import express from 'express'
 import authCtrl from '../controllers/auth.controller'
+import userCtrl from '../controllers/user.controller'
 import conversationCtrl from '../controllers/conversation.controller'
 
 const router = express.Router()
 
 router.route('/api/messages')
-    .post(authCtrl.requireSignin, conversationCtrl.createConv) // Create conversation authCtrl.requireSignin, 
+    .post(authCtrl.requireSignin, authCtrl.hasAuthorizationForNewMessage, conversationCtrl.createConv) // Create conversation authCtrl.requireSignin, 
 
 // authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation
 // Erstelle Nachricht in bestimmter Conversation, erhalte bestimmte Conversation
+// Loesche Konversation
 router.route('/api/messages/:convId')
     .get(authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation, conversationCtrl.read)
     .post(authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation, conversationCtrl.writeMessage)
+    .delete(authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation, conversationCtrl.deleteConvByID)
 
 // Erhalte bestimmte Nachricht??
 
 // Erhalte alle Conversations in denen der User beteiligt ist
 router.route('/api/messages/user/:userId')
-    .get(authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation, conversationCtrl.getConvByUser)
+    .get(authCtrl.requireSignin, authCtrl.hasAuthorization, conversationCtrl.getConvByUser)
 
-// Loesche Konversation
 
 
 router.param('convId', conversationCtrl.convByID)
+router.param('userId', userCtrl.userByID)
 
 export default router

--- a/server/routes/conversation.routes.js
+++ b/server/routes/conversation.routes.js
@@ -5,19 +5,22 @@ import conversationCtrl from '../controllers/conversation.controller'
 const router = express.Router()
 
 router.route('/api/messages')
-    .post(conversationCtrl.createConv) // Create conversation authCtrl.requireSignin, 
+    .post(authCtrl.requireSignin, conversationCtrl.createConv) // Create conversation authCtrl.requireSignin, 
 
 // authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation
 // Erstelle Nachricht in bestimmter Conversation, erhalte bestimmte Conversation
 router.route('/api/messages/:convId')
-    .get(conversationCtrl.read)
-    .post(conversationCtrl.writeMessage)
+    .get(authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation, conversationCtrl.read)
+    .post(authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation, conversationCtrl.writeMessage)
 
 // Erhalte bestimmte Nachricht??
 
 // Erhalte alle Conversations in denen der User beteiligt ist
 router.route('/api/messages/user/:userId')
-    .get(conversationCtrl.getConvByUser)
+    .get(authCtrl.requireSignin, authCtrl.hasAuthorizationForConversation, conversationCtrl.getConvByUser)
+
+// Loesche Konversation
+
 
 router.param('convId', conversationCtrl.convByID)
 


### PR DESCRIPTION
Dieser PR führt Autorisierungen für fast alle Routen ein. User können jetzt nur noch ihre eigenen Konversationen sehen und löschen und müssen nun als Sender zwingend eingetragen sein. 

Unterhaltungen können jetzt gelöscht werden.

Des Weiteren können User jetzt ihre Bücher verändern und auch das Bild des Buches verändern (mit neuer Route). Zur Zeit wird das alte Bild nur verschoben (ist als Test gedacht, in der Zukunft können die Bilder gelöscht werden). Zum Löschen gibt es jetzt im book model die BookImageId, damit kann auf imagekit sicher gelöscht werden. 

Happy testing!

